### PR TITLE
Base ostatus on ratom.

### DIFF
--- a/lib/ostatus.rb
+++ b/lib/ostatus.rb
@@ -1,5 +1,3 @@
-require 'nokogiri'
-
 require_relative 'ostatus/feed'
 require_relative 'ostatus/entry'
 require_relative 'ostatus/author'

--- a/lib/ostatus/activity.rb
+++ b/lib/ostatus/activity.rb
@@ -1,8 +1,3 @@
-# it is unfortunate that ratom doesn't do this on its own.
-class Atom::Person
-  include Atom::SimpleExtensions
-end
-
 module OStatus
   ACTIVITY_NS = 'http://activitystrea.ms/spec/1.0/'
 
@@ -10,9 +5,7 @@ module OStatus
   class Activity
 
     # This will create an instance of an Activity class populated
-    # with the given data as a Hash or parsable XML given by a 
-    # Nokogiri::XML::Element that serves as the root node of
-    # anything containing the activity tags.
+    # from the ratom element (e.g. Atom::Entry) that contains the activity tags
     def initialize(entry)
       @entry = entry
     end

--- a/lib/ostatus/activity.rb
+++ b/lib/ostatus/activity.rb
@@ -1,4 +1,5 @@
 module OStatus
+  ACTIVITY_NS = 'http://activitystrea.ms/spec/1.0/'
 
   # This class represents an Activity object for an OStatus entry.
   class Activity
@@ -7,47 +8,28 @@ module OStatus
     # with the given data as a Hash or parsable XML given by a 
     # Nokogiri::XML::Element that serves as the root node of
     # anything containing the activity tags.
-    def initialize(activity_root)
-      if activity_root.class == Hash
-        @activity_data = activity_root
-        @activity = nil
-      else
-        @activity = activity_root
-        @activity_data = nil
-      end
+    def initialize(entry)
+      @entry = entry
     end
-
-    def pick_first_node(a)
-      if a.empty?
-        nil
-      else
-        a[0].content
-      end
-    end
-    private :pick_first_node
 
     # Returns the object field or nil if it does not exist.
     def object
-      return @activity_data[:object] unless @activity_data == nil
-      pick_first_node(@activity.xpath('./activity:object'))
+      @entry[ACTIVITY_NS, 'object'].first
     end
 
     # Returns the target field or nil if it does not exist.
     def target
-      return @activity_data[:target] unless @activity_data == nil
-      pick_first_node(@activity.xpath('./activity:target'))
+      @entry[ACTIVITY_NS, 'target'].first
     end
 
     # Returns the verb field or nil if it does not exist.
     def verb
-      return @activity_data[:verb] unless @activity_data == nil
-      pick_first_node(@activity.xpath('./activity:verb'))
+      @entry[ACTIVITY_NS, 'verb'].first
     end
 
     # Returns the object-type field or nil if it does not exist.
     def object_type
-      return @activity_data[:object_type] unless @activity_data == nil
-      pick_first_node(@activity.xpath('./activity:object-type'))
+      @entry[ACTIVITY_NS, 'object-type'].first
     end
 
     # Returns a hash of all relevant fields.

--- a/lib/ostatus/activity.rb
+++ b/lib/ostatus/activity.rb
@@ -1,3 +1,8 @@
+# it is unfortunate that ratom doesn't do this on its own.
+class Atom::Person
+  include Atom::SimpleExtensions
+end
+
 module OStatus
   ACTIVITY_NS = 'http://activitystrea.ms/spec/1.0/'
 

--- a/lib/ostatus/author.rb
+++ b/lib/ostatus/author.rb
@@ -7,16 +7,10 @@ module OStatus
   class Author
 
     # Instantiates an Author object either from a given <author></author> root
-    # passed as an instance of a Nokogiri::XML::Element or a Hash containing
+    # passed as an instance of an ratom Atom::Author or a Hash containing
     # the properties.
-    def initialize(author_node)
-      if author_node.class == Hash
-        @author_data = author_node
-        @author = nil
-      else
-        @author = author_node
-        @author_data = nil
-      end
+    def initialize(author)
+      @author = author
     end
 
     # Gives an instance of an OStatus::Activity that parses the fields
@@ -25,31 +19,19 @@ module OStatus
       OStatus::Activity.new(@author)
     end
 
-    def pick_first_node(a)
-      if a.empty?
-        nil
-      else
-        a[0].content
-      end
-    end
-    private :pick_first_node
-
     # Returns the name of the author, if it exists.
     def name
-      return @author_data[:name] unless @author_data == nil
-      pick_first_node(@author.css('name'))
+      @author.name
     end
 
     # Returns the email of the author, if it exists.
     def email
-      return @author_data[:email] unless @author_data == nil
-      pick_first_node(@author.css('email'))
+      @author.email
     end
 
     # Returns the uri of the author, if it exists.
     def uri
-      return @author_data[:uri] unless @author_data == nil
-      pick_first_node(@author.css('uri'))
+      @author.uri
     end
 
     # Returns an instance of a PortableContacts that further describe the

--- a/lib/ostatus/author.rb
+++ b/lib/ostatus/author.rb
@@ -13,9 +13,10 @@ module OStatus
     element 'poco:id'
     element 'poco:displayName'
     element 'poco:nickname'
-    element 'poco:published'
-    element 'poco:birthday'
-    element 'poco:anniversary'
+    element 'poco:updated',     :class => DateTime, :content_only => true
+    element 'poco:published',   :class => DateTime, :content_only => true
+    element 'poco:birthday',    :class => Date, :content_only => true
+    element 'poco:anniversary', :class => Date, :content_only => true
     element 'poco:gender'
     element 'poco:note'
     element 'poco:preferredUsername'
@@ -68,8 +69,8 @@ module OStatus
     end
 
     def portable_contacts= poco
-      [ 'id', 'name', 'nickname', 'published', 'birthday', 'anniversary',
-        'gender', 'note', 'connected'].each do |p|
+      [ 'id', 'name', 'nickname', 'updated', 'published', 'birthday',
+        'anniversary', 'gender', 'note', 'connected'].each do |p|
         v = poco.send(p)
         self.send("poco_#{p}=", v) if v
       end

--- a/lib/ostatus/author.rb
+++ b/lib/ostatus/author.rb
@@ -5,6 +5,8 @@ module OStatus
 
   # Holds information about the author of the Feed.
   class Author < Atom::Person
+    include Atom::SimpleExtensions
+
     namespace Atom::NAMESPACE
     element :email
     element :uri

--- a/lib/ostatus/entry.rb
+++ b/lib/ostatus/entry.rb
@@ -52,6 +52,10 @@ module OStatus
       result
     end
 
+    def link= options
+      links.clear << Atom::Link.new(options)
+    end
+
     # Returns a Hash of all fields.
     def info
       {

--- a/lib/ostatus/entry.rb
+++ b/lib/ostatus/entry.rb
@@ -35,12 +35,12 @@ module OStatus
 
     # Returns the DateTime that this entry was published.
     def published
-      DateTime.parse(@entry.published.to_s)
+      DateTime.parse(@entry.published.to_s).new_offset(0)
     end
 
     # Returns the DateTime that this entry was updated.
     def updated
-      DateTime.parse(@entry.updated.to_s)
+      DateTime.parse(@entry.updated.to_s).new_offset(0)
     end
 
     # Returns the id of the entry.

--- a/lib/ostatus/entry.rb
+++ b/lib/ostatus/entry.rb
@@ -39,17 +39,7 @@ module OStatus
     end
 
     def link
-      result = {}
-
-      links.each do |l|
-        if l.rel
-          rel = l.rel.intern
-          result[rel] ||= []
-          result[rel] << l
-        end
-      end
-
-      result
+      links.group_by { |l| l.rel.intern }
     end
 
     def link= options

--- a/lib/ostatus/feed.rb
+++ b/lib/ostatus/feed.rb
@@ -17,7 +17,7 @@ module OStatus
       @options = options
 
       if options.nil?
-        @f = Atom::Feed.load_feed(self.atom)
+        @feed = Atom::Feed.load_feed(self.atom)
       end
     end
 
@@ -46,7 +46,7 @@ module OStatus
     #                              returns the contents of the href attribute.
     #
     def link(attribute)
-      @f.links.find_all { |l| l.rel == attribute.to_s }
+      @feed.links.find_all { |l| l.rel == attribute.to_s }
     end
 
     # Returns an array of URLs for each hub link tag.
@@ -155,16 +155,13 @@ module OStatus
     # Returns an OStatus::Author that will parse the author information
     # within the Feed.
     def author
-      return @options[:author] unless @options == nil
-
-      author_xml = @xml.at_css('author')
-      OStatus::Author.new(author_xml)
+      OStatus::Author.new(@feed.authors.first)
     end
 
     # This method gives you an array of OStatus::Entry instances for 
     # each entry listed in the feed.
     def entries
-      @f.entries.map do |entry|
+      @feed.entries.map do |entry|
         OStatus::Entry.new(entry)
       end
     end

--- a/lib/ostatus/feed.rb
+++ b/lib/ostatus/feed.rb
@@ -69,6 +69,15 @@ module OStatus
       links.find_all { |l| l.rel == attribute.to_s }
     end
 
+    def links=(given)
+      self.links.clear
+      given.each do |rel,links|
+        links.each do |l|
+          self.links << Atom::Link.new(l.merge({:rel => rel}))
+        end
+      end
+    end
+
     # Returns an array of URLs for each hub link tag.
     def hubs
       link(:hub).map { |link| link.href }
@@ -92,6 +101,7 @@ module OStatus
         # open the url through OAuth
         @access_token.get(@url).body
       else
+        self.links << Atom::Link.new(:rel => 'self', :href => @url) if @url
         self.to_xml
       end
     end

--- a/lib/ostatus/feed.rb
+++ b/lib/ostatus/feed.rb
@@ -9,22 +9,45 @@ require_relative 'author'
 module OStatus
 
   # This class represents an OStatus Feed object.
-  class Feed
+  class Feed < Atom::Feed
+    namespace Atom::NAMESPACE
+
+    element :id, :rights
+    element :generator, :class => Atom::Generator
+    element :title, :subtitle, :class => Atom::Content
+    element :updated, :class => Time, :content_only => true
+    elements :links, :class => Atom::Link
+    elements :authors, :class => OStatus::Author
+    elements :categories, :class => Atom::Category
+    elements :entries, :class => OStatus::Entry
+
+    attr_reader :url
+
     def initialize(str, url, access_token, options)
       @str = str
       @url = url
       @access_token = access_token
       @options = options
 
-      if options.nil?
-        @feed = Atom::Feed.load_feed(self.atom)
+      if str
+        super(XML::Reader.string(str))
+      else
+        super(options)
       end
     end
 
     # Creates a new Feed instance given by the atom feed located at 'url'
     # and optionally using the OAuth::AccessToken given.
     def Feed.from_url(url, access_token = nil)
-      Feed.new(nil, url, access_token, nil)
+      if access_token.nil?
+        # simply open the url
+        str = open(url).read
+      else
+        # open the url through OAuth
+        str = access_token.get(url).body
+      end
+
+      Feed.new(str, url, access_token, nil)
     end
 
     # Creates a new Feed instance that contains the information given by
@@ -46,7 +69,7 @@ module OStatus
     #                              returns the contents of the href attribute.
     #
     def link(attribute)
-      @feed.links.find_all { |l| l.rel == attribute.to_s }
+      links.find_all { |l| l.rel == attribute.to_s }
     end
 
     # Returns an array of URLs for each hub link tag.
@@ -59,20 +82,6 @@ module OStatus
     # Returns the salmon URL from the link tag.
     def salmon
       link(:salmon).first.href
-    end
-
-    # Returns the logo
-    def logo
-      return @options[:logo] unless @options == nil
-
-      pick_first_node(@xml.xpath('/xmlns:feed/xmlns:logo'))
-    end
-
-    # Returns the icon
-    def icon
-      return @options[:icon] unless @options == nil
-
-      pick_first_node(@xml.xpath('/xmlns:feed/xmlns:icon'))
     end
 
     # This method will return a String containing the actual content of
@@ -88,82 +97,20 @@ module OStatus
         # open the url through OAuth
         @access_token.get(@url).body
       else
-        # build the atom file from internal information
-        feed = TinyAtom::Feed.new(
-          self.id,
-          self.title,
-
-          @url,
-
-          :author_name => self.author.name,
-          :author_email => self.author.email,
-          :author_uri => self.author.uri,
-
-          :hubs => self.hubs
-        )
-
-        @options[:entries].each do |entry|
-          entry_url = entry.url
-          entry_url = @url if entry_url == nil
-
-          feed.add_entry(
-            entry.id,
-            entry.title,
-            entry.updated,
-
-            entry_url,
-
-            :published => entry.published,
-
-            :content => entry.content,
-
-            :author_name => self.author.name,
-            :author_email => self.author.email,
-            :author_uri => self.author.uri
-          )
-        end
-
-        feed.make(:indent => 2)
+        self.to_xml
       end
-    end
-
-    def pick_first_node(a)
-      if a.empty?
-        nil
-      else
-        a[0].content
-      end
-    end
-    private :pick_first_node
-
-    def id
-      return @options[:id] unless @options == nil
-
-      pick_first_node(@xml.xpath('/xmlns:feed/xmlns:id'))
-    end
-
-    def title
-      return @options[:title] unless @options == nil
-
-      pick_first_node(@xml.xpath('/xmlns:feed/xmlns:title'))
-    end
-
-    def url
-      return @url
     end
 
     # Returns an OStatus::Author that will parse the author information
     # within the Feed.
     def author
-      OStatus::Author.new(@feed.authors.first)
+      return @options[:author] unless @options.nil?
+
+      self.authors.first
     end
 
-    # This method gives you an array of OStatus::Entry instances for 
-    # each entry listed in the feed.
-    def entries
-      @feed.entries.map do |entry|
-        OStatus::Entry.new(entry)
-      end
+    def author= author
+      self.authors.clear << author
     end
   end
 end

--- a/lib/ostatus/feed.rb
+++ b/lib/ostatus/feed.rb
@@ -58,13 +58,12 @@ module OStatus
       Feed.new(str, nil, nil, nil)
     end
 
-    # Returns an array of  Nokogiri::XML::Element instances for all link tags
-    # that have a rel equal to that given by attribute. This can be used 
-    # generally as a Hash where the keys are intern strings that give an attribute.
+    # Returns an array of Atom::Link instances for all link tags
+    # that have a rel equal to that given by attribute.
     #
     # For example:
-    #   link(:hub).first[:href] -- Gets the first link tag with rel="hub" and
-    #                              returns the contents of the href attribute.
+    #   link(:hub).first.href -- Gets the first link tag with rel="hub" and
+    #                            returns the contents of the href attribute.
     #
     def link(attribute)
       links.find_all { |l| l.rel == attribute.to_s }

--- a/lib/ostatus/feed.rb
+++ b/lib/ostatus/feed.rb
@@ -10,7 +10,7 @@ module OStatus
   class Feed < Atom::Feed
     namespace Atom::NAMESPACE
 
-    element :id, :rights
+    element :id, :rights, :icon, :logo
     element :generator, :class => Atom::Generator
     element :title, :subtitle, :class => Atom::Content
     element :updated, :class => Time, :content_only => true

--- a/lib/ostatus/feed.rb
+++ b/lib/ostatus/feed.rb
@@ -74,9 +74,7 @@ module OStatus
 
     # Returns an array of URLs for each hub link tag.
     def hubs
-      link(:hub).map do |link|
-        link.href
-      end
+      link(:hub).map { |link| link.href }
     end
 
     # Returns the salmon URL from the link tag.
@@ -104,9 +102,7 @@ module OStatus
     # Returns an OStatus::Author that will parse the author information
     # within the Feed.
     def author
-      return @options[:author] unless @options.nil?
-
-      self.authors.first
+      @options ? @options[:author] : self.authors.first
     end
 
     def author= author

--- a/lib/ostatus/feed.rb
+++ b/lib/ostatus/feed.rb
@@ -1,6 +1,4 @@
-require 'nokogiri'
 require 'open-uri'
-require 'tinyatom'
 require 'atom'
 
 require_relative 'entry'

--- a/lib/ostatus/portable_contacts.rb
+++ b/lib/ostatus/portable_contacts.rb
@@ -1,20 +1,15 @@
 module OStatus
+  POCO_NS = 'http://portablecontacts.net/spec/1.0'
 
   # Holds information about the extended contact information
   # in the Feed given in the Portable Contacts specification.
   class PortableContacts
     
     # Instantiates a OStatus::PortableContacts object from either
-    # a given root that contains all <poco:*> tags as a
-    # Nokogiri::XML::Element or a Hash containing the properties.
-    def initialize(author_node)
-      if author_node.class == Hash
-        @poco_data = author_node
-        @poco = nil
-      else
-        @poco = author_node
-        @poco_data = nil
-      end
+    # a given root that contains all <poco:*> tags as an ratom Person
+    #  or a Hash containing the properties.
+    def initialize(poco)
+      @poco = poco
     end
 
     def pick_first_node(a)
@@ -100,17 +95,14 @@ module OStatus
 
     # Returns the preferred username of the contact, if it exists.
     def preferred_username
-      return @poco_data[:preferred_username] unless @poco_data == nil
-      pick_first_node(@poco.xpath('./poco:preferredUsername'))
+      @poco[POCO_NS, 'preferredUsername'].first
     end
 
     # Returns a boolean that indicates that a bi-directional connection
     # has been established between the user and the contact, if it is
     # able to assert this.
     def connected
-      return @poco_data[:connected] unless @poco_data == nil
-      str = pick_first_node(@poco.xpath('./poco:connected'))
-      return nil if str == nil
+      str = @poco[POCO_NS, 'connected'].first
 
       if str == "true"
         true

--- a/lib/ostatus/portable_contacts.rb
+++ b/lib/ostatus/portable_contacts.rb
@@ -8,82 +8,110 @@ module OStatus
     # Instantiates a OStatus::PortableContacts object from either
     # a given root that contains all <poco:*> tags as an ratom Person
     #  or a Hash containing the properties.
-    def initialize(poco)
-      @poco = poco
+    def initialize(parent)
+      if parent.is_a? Hash
+        @options = parent
+      else
+        @parent = parent
+      end
     end
 
     # Returns the id of the contact, if it exists.
     def id
-      @poco[POCO_NS, 'id'].first
+      return @options[:id] unless @options.nil?
+      @parent.poco_id
     end
 
     # Returns the display_name of the contact, if it exists.
     def display_name
-      @poco[POCO_NS, 'displayName'].first
+      return @options[:display_name] unless @options.nil?
+      @parent.poco_displayName
     end
 
     # Returns the name of the contact, if it exists.
     def name
-      @poco[POCO_NS, 'name'].first
+      return @options[:name] unless @options.nil?
+      @parent.poco_name
     end
 
     # Returns the nickname of the contact, if it exists.
     def nickname
-      @poco[POCO_NS, 'nickname'].first
+      return @options[:nick_name] unless @options.nil?
+      @parent.poco_nickname
     end
 
     # Returns the published of the contact, if it exists.
     def published
-      date = @poco[POCO_NS, 'published'].first
-      unless date.nil?
-        DateTime.parse(date)
+      if @options.nil?
+        @parent.poco_published
+      else
+        date = @options[:published]
+        unless date.nil?
+          DateTime.parse(date)
+        end
       end
     end
 
     # Returns the updated of the contact, if it exists.
     def updated
-      date = @poco[POCO_NS, 'updated'].first
-      unless date.nil?
-        DateTime.parse(date)
+      if @options.nil?
+        @parent.poco_updated
+      else
+        date = @options[:updated]
+        unless date.nil?
+          DateTime.parse(date)
+        end
       end
     end
 
     # Returns the birthday of the contact, if it exists.
     def birthday
-      date = @poco[POCO_NS, 'birthday'].first
-      unless date.nil?
-        Date.parse(date)
+      if @options.nil?
+        @parent.poco_birthday
+      else
+        date = @options[:birthday]
+        unless date.nil?
+          Date.parse(date)
+        end
       end
     end
 
     # Returns the anniversary of the contact, if it exists.
     def anniversary
-      date = @poco[POCO_NS, 'anniversary'].first
-      unless date.nil?
-        Date.parse(date)
+      if @options.nil?
+        @parent.poco_anniversary
+      else
+        date = @options[:anniversary]
+        unless date.nil?
+          Date.parse(date)
+        end
       end
     end
 
     # Returns the gender of the contact, if it exists.
     def gender
-      @poco[POCO_NS, 'gender'].first
+      return @options[:gender] unless @options.nil?
+      @parent.poco_gender
     end
 
     # Returns the note of the contact, if it exists.
     def note
-      @poco[POCO_NS, 'note'].first
+      return @options[:note] unless @options.nil?
+      @parent.poco_note
     end
 
     # Returns the preferred username of the contact, if it exists.
     def preferred_username
-      @poco[POCO_NS, 'preferredUsername'].first
+      return @options[:preferred_username] unless @options.nil?
+      @parent.poco_preferredUsername
     end
 
     # Returns a boolean that indicates that a bi-directional connection
     # has been established between the user and the contact, if it is
     # able to assert this.
     def connected
-      str = @poco[POCO_NS, 'connected'].first
+      return @options[:connected] unless @options.nil?
+      str = @parent.poco_connected
 
       if str == "true"
         true

--- a/lib/ostatus/portable_contacts.rb
+++ b/lib/ostatus/portable_contacts.rb
@@ -12,85 +12,66 @@ module OStatus
       @poco = poco
     end
 
-    def pick_first_node(a)
-      if a.empty?
-        nil
-      else
-        a[0].content
-      end
-    end
-    private :pick_first_node
-
     # Returns the id of the contact, if it exists.
     def id
-      return @poco_data[:id] unless @poco_data == nil
-      pick_first_node(@poco.xpath('./poco:id'))
+      @poco[POCO_NS, 'id'].first
     end
 
     # Returns the display_name of the contact, if it exists.
     def display_name
-      return @poco_data[:display_name] unless @poco_data == nil
-      pick_first_node(@poco.xpath('./poco:displayName'))
+      @poco[POCO_NS, 'displayName'].first
     end
 
     # Returns the name of the contact, if it exists.
     def name
-      return @poco_data[:name] unless @poco_data == nil
-      pick_first_node(@poco.xpath('./poco:name'))
+      @poco[POCO_NS, 'name'].first
     end
 
     # Returns the nickname of the contact, if it exists.
     def nickname
-      return @poco_data[:nickname] unless @poco_data == nil
-      pick_first_node(@poco.xpath('./poco:nickname'))
+      @poco[POCO_NS, 'nickname'].first
     end
 
     # Returns the published of the contact, if it exists.
     def published
-      return @poco_data[:published] unless @poco_data == nil
-      pub = pick_first_node(@poco.xpath('./poco:published'))
-      if pub != nil
-        DateTime.parse(pub)
+      date = @poco[POCO_NS, 'published'].first
+      unless date.nil?
+        DateTime.parse(date)
       end
     end
 
     # Returns the updated of the contact, if it exists.
     def updated
-      return @poco_data[:updated] unless @poco_data == nil
-      upd = pick_first_node(@poco.xpath('./poco:updated'))
-      if upd != nil
-        DateTime.parse(upd)
+      date = @poco[POCO_NS, 'updated'].first
+      unless date.nil?
+        DateTime.parse(date)
       end
     end
 
     # Returns the birthday of the contact, if it exists.
     def birthday
-      return @poco_data[:birthday] unless @poco_data == nil
-      bday = pick_first_node(@poco.xpath('./poco:birthday'))
-      if bday != nil
-        Date.parse(bday)
+      date = @poco[POCO_NS, 'birthday'].first
+      unless date.nil?
+        Date.parse(date)
       end
     end
 
     # Returns the anniversary of the contact, if it exists.
     def anniversary
-      return @poco_data[:anniversary] unless @poco_data == nil
-      anni = pick_first_node(@poco.xpath('./poco:anniversary'))
-      if anni != nil
-        Date.parse(anni)
+      date = @poco[POCO_NS, 'anniversary'].first
+      unless date.nil?
+        Date.parse(date)
       end
     end
 
     # Returns the gender of the contact, if it exists.
     def gender
-      return @poco_data[:gender] unless @poco_data == nil
-      pick_first_node(@poco.xpath('./poco:gender'))
+      @poco[POCO_NS, 'gender'].first
     end
 
     # Returns the note of the contact, if it exists.
     def note
-      return @poco_data[:note] unless @poco_data == nil
-      pick_first_node(@poco.xpath('./poco:note'))
+      @poco[POCO_NS, 'note'].first
     end
 
     # Returns the preferred username of the contact, if it exists.

--- a/lib/ostatus/portable_contacts.rb
+++ b/lib/ostatus/portable_contacts.rb
@@ -4,7 +4,7 @@ module OStatus
   # Holds information about the extended contact information
   # in the Feed given in the Portable Contacts specification.
   class PortableContacts
-    
+
     # Instantiates a OStatus::PortableContacts object from either
     # a given root that contains all <poco:*> tags as an ratom Person
     #  or a Hash containing the properties.
@@ -16,95 +16,20 @@ module OStatus
       end
     end
 
-    # Returns the id of the contact, if it exists.
-    def id
-      return @options[:id] unless @options.nil?
-      @parent.poco_id
-    end
+    def id;         get_prop(:id); end
+    def name;       get_prop(:name); end
+    def nickname;   get_prop(:nickname); end
+    def gender;     get_prop(:gender); end
+    def note;       get_prop(:note); end
 
-    # Returns the display_name of the contact, if it exists.
-    def display_name
-      return @options[:display_name] unless @options.nil?
-      @parent.poco_displayName
-    end
+    def display_name;       get_prop(:display_name, 'displayName'); end
+    def preferred_username; get_prop(:preferred_username, 'preferredUsername'); end
 
-    # Returns the name of the contact, if it exists.
-    def name
-      return @options[:name] unless @options.nil?
-      @parent.poco_name
-    end
+    def updated;   get_datetime(:updated); end
+    def published; get_datetime(:published); end
 
-    # Returns the nickname of the contact, if it exists.
-    def nickname
-      return @options[:nick_name] unless @options.nil?
-      @parent.poco_nickname
-    end
-
-    # Returns the published of the contact, if it exists.
-    def published
-      if @options.nil?
-        @parent.poco_published
-      else
-        date = @options[:published]
-        unless date.nil?
-          DateTime.parse(date)
-        end
-      end
-    end
-
-    # Returns the updated of the contact, if it exists.
-    def updated
-      if @options.nil?
-        @parent.poco_updated
-      else
-        date = @options[:updated]
-        unless date.nil?
-          DateTime.parse(date)
-        end
-      end
-    end
-
-    # Returns the birthday of the contact, if it exists.
-    def birthday
-      if @options.nil?
-        @parent.poco_birthday
-      else
-        date = @options[:birthday]
-        unless date.nil?
-          Date.parse(date)
-        end
-      end
-    end
-
-    # Returns the anniversary of the contact, if it exists.
-    def anniversary
-      if @options.nil?
-        @parent.poco_anniversary
-      else
-        date = @options[:anniversary]
-        unless date.nil?
-          Date.parse(date)
-        end
-      end
-    end
-
-    # Returns the gender of the contact, if it exists.
-    def gender
-      return @options[:gender] unless @options.nil?
-      @parent.poco_gender
-    end
-
-    # Returns the note of the contact, if it exists.
-    def note
-      return @options[:note] unless @options.nil?
-      @parent.poco_note
-    end
-
-    # Returns the preferred username of the contact, if it exists.
-    def preferred_username
-      return @options[:preferred_username] unless @options.nil?
-      @parent.poco_preferredUsername
-    end
+    def birthday;    get_date(:birthday); end
+    def anniversary; get_date(:anniversary); end
 
     # Returns a boolean that indicates that a bi-directional connection
     # has been established between the user and the contact, if it is
@@ -121,5 +46,30 @@ module OStatus
         nil
       end
     end
+
+  private
+
+    def get_prop name, xmlName = name
+      @options ? @options[name] : @parent.send("poco_#{xmlName}")
+    end
+
+    def get_datetime x
+      if @options
+        dt = @options[x]
+        DateTime.parse(dt) if dt
+      else
+        @parent.send("poco_#{x}")
+      end
+    end
+
+    def get_date x
+      if @options
+        d = @options[x]
+        Date.parse(d) if d
+      else
+        @parent.send("poco_#{x}")
+      end
+    end
+
   end
 end

--- a/ostatus.gemspec
+++ b/ostatus.gemspec
@@ -15,8 +15,6 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "ostatus"
 
   s.add_dependency "oauth"
-  s.add_dependency "nokogiri"
-  s.add_dependency "tinyatom"
   s.add_dependency "ratom"
   s.add_development_dependency "rspec"
 

--- a/ostatus.gemspec
+++ b/ostatus.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency "oauth"
   s.add_dependency "nokogiri"
   s.add_dependency "tinyatom"
+  s.add_dependency "ratom"
   s.add_development_dependency "rspec"
 
   s.files         = `git ls-files`.split("\n")

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -3,7 +3,8 @@ require_relative '../lib/ostatus/feed.rb'
 describe 'XML builder' do
   before(:each) do
     @feed_url = 'http://example.org/feed'
-    @poco     = OStatus::PortableContacts.new(:id => '68b329da9893e34099c7d8ad5cb9c940',
+    @poco_id  = '68b329da9893e34099c7d8ad5cb9c940'
+    @poco     = OStatus::PortableContacts.new(:id => @poco_id,
                                               :display_name => 'Dean Venture',
                                               :preferred_username => 'dean')
     @author   = OStatus::Author.new(:name => 'Dean Venture',
@@ -15,18 +16,22 @@ describe 'XML builder' do
                                     :id => @feed_url,
                                     :author => @author,
                                     :entries => [])
-    puts @feed.atom
   end
 
   it 'should generate the title' do
-    @feed.atom.should match(/<title>Dean's Updates/)
+    @feed.atom.should match("<title>Dean's Updates")
   end
 
   it 'should generate the id' do
-    @feed.atom.should match(/<id>#{@feed_url}/)
+    @feed.atom.should match("<id>#{@feed_url}")
   end
 
-  it 'should generate the author' do
-    @feed.atom.should match(/<name>Dean Venture/)
+  describe 'when generating the author' do
+    specify { @feed.atom.should match('<name>Dean Venture') }
+    specify { @feed.atom.should match('<email>dean@venture.com') }
+    specify { @feed.atom.should match('<uri>http://geocities.com/~dean') }
+    specify { @feed.atom.should match("<poco:id>#{@poco_id}") }
+    specify { @feed.atom.should match('<poco:displayName>Dean Venture') }
+    specify { @feed.atom.should match('<poco:preferredUsername>dean') }
   end
 end

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -15,7 +15,10 @@ describe 'XML builder' do
                                     :title => "Dean's Updates",
                                     :id => @feed_url,
                                     :author => @author,
-                                    :entries => [])
+                                    :entries => [],
+                                    :links => {
+                                      :hub => [{:href => 'http://example.org/hub'}]
+                                    })
   end
 
   it 'should generate the title' do
@@ -24,6 +27,16 @@ describe 'XML builder' do
 
   it 'should generate the id' do
     @feed.atom.should match("<id>#{@feed_url}")
+  end
+
+  it 'should generate a self link' do
+    # depending on this attribute order is a really terrible idea, but oh well.
+    @feed.atom.should match("<link rel=\"self\" href=\"#{@feed_url}\"/>")
+  end
+
+  it 'should generate the hub link' do
+    # depending on this attribute order is a really terrible idea, but oh well.
+    @feed.atom.should match('<link rel="hub" href="http://example.org/hub"/>')
   end
 
   describe 'when generating the author' do

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -34,4 +34,26 @@ describe 'XML builder' do
     specify { @feed.atom.should match('<poco:displayName>Dean Venture') }
     specify { @feed.atom.should match('<poco:preferredUsername>dean') }
   end
+
+  describe 'when generating a feed with entries' do
+    before do
+      @now = Time.now
+
+      @feed.entries << OStatus::Entry.new(
+        :title => 'atom powered robots are running amok lol',
+        :content => 'atom powered robots are running amok lol',
+        :updated => @now,
+        :published => @now,
+        :id => 'http://example.org/feed/1',
+        :link => { :href => 'http://example.org/feed/1' }
+      )
+    end
+
+    specify { @feed.atom.should match('<title>atom powered robots') }
+    specify { @feed.atom.should match('<content>atom powered robots') }
+    specify { @feed.atom.should match("<updated>#{@now.iso8601}") }
+    specify { @feed.atom.should match("<published>#{@now.iso8601}") }
+    specify { @feed.atom.should match('<id>http://example.org/feed/1') }
+    specify { @feed.atom.should match('<link href="http://example.org/feed/1"/>') }
+  end
 end

--- a/test/example_feed.atom
+++ b/test/example_feed.atom
@@ -22,11 +22,11 @@
 		<poco:id>foobar</poco:id>
 		<poco:name>barbaz</poco:name>
 		<poco:nickname>spaz</poco:nickname>
-		<poco:published>2012-02-21T02:15:14+00:00</pico:published>
-		<poco:updated>2013-02-21T02:15:14+00:00</pico:updated>
-		<poco:birthday>2014-02-21</pico:birthday>
-		<poco:anniversary>2015-02-21</pico:anniversary>
-		<poco:gender>male</pico:gender>
+		<poco:published>2012-02-21T02:15:14+00:00</poco:published>
+		<poco:updated>2013-02-21T02:15:14+00:00</poco:updated>
+		<poco:birthday>2014-02-21</poco:birthday>
+		<poco:anniversary>2015-02-21</poco:anniversary>
+		<poco:gender>male</poco:gender>
 		<poco:note>foo
 bar</poco:note>
 		<poco:utcOffset>-08:00</poco:utcOffset>
@@ -72,7 +72,7 @@ bar</poco:note>
 	<entry>
 		<activity:object-type>http://activitystrea.ms/schema/1.0/note</activity:object-type>
 		<activity:object>Foobar</activity:object>
-		<activity:target>Barbaz</activity:object>
+		<activity:target>Barbaz</activity:target>
 		<id>http://identi.ca/notice/64991641</id>
 		<title>staples come out of the head tomorrow, oh yeah</title>
 		<content type="html">staples come out of the head tomorrow, oh yeah</content>

--- a/test/example_feed_empty_author.atom
+++ b/test/example_feed_empty_author.atom
@@ -48,7 +48,7 @@
 	<entry>
 		<activity:object-type>http://activitystrea.ms/schema/1.0/note</activity:object-type>
 		<activity:object>Foobar</activity:object>
-		<activity:target>Barbaz</activity:object>
+		<activity:target>Barbaz</activity:target>
 		<id>http://identi.ca/notice/64991641</id>
 		<title>staples come out of the head tomorrow, oh yeah</title>
 		<content type="html">staples come out of the head tomorrow, oh yeah</content>

--- a/test/example_feed_false_connected.atom
+++ b/test/example_feed_false_connected.atom
@@ -22,11 +22,11 @@
 		<poco:id>foobar</poco:id>
 		<poco:name>barbaz</poco:name>
 		<poco:nickname>spaz</poco:nickname>
-		<poco:published>2012-02-21T02:15:14+00:00</pico:published>
-		<poco:updated>2013-02-21T02:15:14+00:00</pico:updated>
-		<poco:birthday>2014-02-21</pico:birthday>
-		<poco:anniversary>2015-02-21</pico:anniversary>
-		<poco:gender>male</pico:gender>
+		<poco:published>2012-02-21T02:15:14+00:00</poco:published>
+		<poco:updated>2013-02-21T02:15:14+00:00</poco:updated>
+		<poco:birthday>2014-02-21</poco:birthday>
+		<poco:anniversary>2015-02-21</poco:anniversary>
+		<poco:gender>male</poco:gender>
 		<poco:note>foo
 bar</poco:note>
 		<poco:utcOffset>-08:00</poco:utcOffset>
@@ -71,7 +71,7 @@ bar</poco:note>
 	<entry>
 		<activity:object-type>http://activitystrea.ms/schema/1.0/note</activity:object-type>
 		<activity:object>Foobar</activity:object>
-		<activity:target>Barbaz</activity:object>
+		<activity:target>Barbaz</activity:target>
 		<id>http://identi.ca/notice/64991641</id>
 		<title>staples come out of the head tomorrow, oh yeah</title>
 		<content type="html">staples come out of the head tomorrow, oh yeah</content>


### PR DESCRIPTION
Instead of doing all the parsing right in ostatus, this branch bases it on Ratom (a libxml Atom library).

The big wins:
1. it eliminates a lot of repetitive code.
2. it can write out poco elements now. With this Rstatus can now add a subscription to a feed on a different Rstatus node (I don't know if the subscription actually does anything, but before this it would just throw a 500 since it was looking for poco elements that weren't being put in the feed)

Ratom also takes care of little details like absolutizing relative URLs and handling namespace prefixes correctly.

I've left the API pretty much the same (the only difference I know of is that `feed.link[:hub].first[:rel]` has changed to `feed.link[:hub].first.rel`). Rstat.us' specs still pass, and a quick click around my local node seems to be ok.
