### PR TITLE
Update ratom, add travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+rvm:
+  - 1.9.2
+  - 1.9.3
+script: "bundle exec rake spec"

--- a/lib/ostatus/author.rb
+++ b/lib/ostatus/author.rb
@@ -1,5 +1,6 @@
 require_relative 'activity'
 require_relative 'portable_contacts'
+require 'date'
 
 module OStatus
 
@@ -30,7 +31,7 @@ module OStatus
     element 'poco:connected'
 
     def initialize *args
-      self.activity_object_type = "http://activitystrea.ms/schema/1.0/person" 
+      self.activity_object_type = "http://activitystrea.ms/schema/1.0/person"
       super(*args)
     end
 

--- a/ostatus.gemspec
+++ b/ostatus.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "ostatus"
 
-  s.add_dependency "ratom"
-  s.add_development_dependency "rspec"
+  s.add_dependency "ratom", "~> 0.7.0"
+  s.add_development_dependency "rspec", "~> 2.10.0"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/ostatus.gemspec
+++ b/ostatus.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "ratom", "~> 0.7.0"
   s.add_development_dependency "rspec", "~> 2.10.0"
+  s.add_development_dependency "rake", "~> 0.9.2"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -64,8 +64,8 @@ describe 'XML builder' do
 
     specify { @feed.atom.should match('<title>atom powered robots') }
     specify { @feed.atom.should match('<content>atom powered robots') }
-    specify { @feed.atom.should match("<updated>#{@now.iso8601}") }
-    specify { @feed.atom.should match("<published>#{@now.iso8601}") }
+    specify { @feed.atom.should match(Regexp.escape("<updated>#{@now.iso8601}")) }
+    specify { @feed.atom.should match(Regexp.escape("<published>#{@now.iso8601}")) }
     specify { @feed.atom.should match('<id>http://example.org/feed/1') }
     specify { @feed.atom.should match('<link href="http://example.org/feed/1"/>') }
   end


### PR DESCRIPTION
Hiii so ratom USED to have a deprecation warning in ruby 1.9.3, which would show up in rstatus test runs, but I helped fix that and there's a new version of ratom out now.

So I updated that and thought, let's travis ALL THE THINGS! With these commits, ostatus passes in 1.9.2 and 1.9.3 on travis.
